### PR TITLE
fix: Pin Tailwind CSS to v3.x to prevent breaking changes from v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "jest": "^30.2.0",
     "jest-environment-jsdom": "^30.2.0",
     "postcss": "^8.4.38",
-    "tailwindcss": "^3.4.4",
+    "tailwindcss": "~3.4.4",
     "ts-jest": "^29.4.5",
     "typescript": "^5.4.5"
   }


### PR DESCRIPTION
Tailwind CSS v4 requires @tailwindcss/postcss plugin instead of direct PostCSS usage. Pinning to ~3.4.4 prevents Dependabot from auto-upgrading to v4 until we're ready to migrate to the new architecture.

This fixes the Vercel deployment error:
'It looks like you're trying to use tailwindcss directly as a PostCSS plugin'