### PR TITLE
feat: Add tri-logic visualizer navigation link to landing page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -77,6 +77,12 @@ export default function Landing() {
             <p className="text-sm text-gray-400">ML‑KEM secure channels and integrity proofs for every response.</p>
           </div>
         </div>
+        <div className="mt-8 text-center">
+          <Link href="/trilogic" className="inline-flex items-center gap-2 px-6 py-3 rounded-lg bg-gradient-to-r from-brand via-brand-purple to-brand-pink text-white font-semibold hover:opacity-90 transition-opacity">
+            <span>🎯 Explore Tri-Logic Visualizer</span>
+            <span className="text-sm opacity-80">Interactive Riemann Sphere</span>
+          </Link>
+        </div>
       </section>
 
       {/* Principles */}

--- a/landing/src/pages/RiemannSpherePage.vue
+++ b/landing/src/pages/RiemannSpherePage.vue
@@ -76,7 +76,7 @@
                     size="lg"
                     class="cta-btn primary-cta"
                     label="Launch Riemann Sphere Visualizer"
-                    href="https://omega-main.vercel.app/trilogic"
+                    href="/trilogic"
                     target="_blank"
                     icon-right="open_in_new"
                   />


### PR DESCRIPTION
- Add prominent link to /trilogic from main landing page features section
- Update Quasar RiemannSpherePage link to use relative path /trilogic
- Improve discoverability of tri-logic visualizer from homepage